### PR TITLE
Fix tests and examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ libc = "0.2"
 static = []
 
 [build-dependencies]
-bindgen = "0.30.0"
+bindgen = "0.51.0"

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,9 @@ fn main() {
 
     let bindings = bindgen::Builder::default()
         .header("src/wrapper.h")
+        .default_enum_style(bindgen::EnumVariation::Rust { non_exhaustive: false })
         .derive_debug(true)
+        .impl_debug(true)
         .constified_enum("cs_mode")
         .generate()
         .expect("Unable to generate bindings");

--- a/examples/implicit.rs
+++ b/examples/implicit.rs
@@ -1,14 +1,14 @@
 // This example shows how to extract out details on implicit registers
 // being read by instructions.
 
-extern crate capstone_rust;
+extern crate falcon_capstone;
 
-use capstone_rust::capstone as cs;
+use falcon_capstone::capstone as cs;
 
 fn main() {
     // Buffer of code.
     let code = vec![0x01, 0xc0, 0xe8, 0x06, 0x00, 0x00, 0x00];
-    let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::cs_mode::CS_MODE_32).unwrap();
+    let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::CS_MODE_32).unwrap();
 
     // Enable detail mode. This is needed if you want to get instruction details.
     dec.option(cs::cs_opt_type::CS_OPT_DETAIL, cs::cs_opt_value::CS_OPT_ON).unwrap();

--- a/examples/insn_groups.rs
+++ b/examples/insn_groups.rs
@@ -1,13 +1,13 @@
 // This example shows how to get the semantic group of an instruction.
 
-extern crate capstone_rust;
+extern crate falcon_capstone;
 
-use capstone_rust::capstone as cs;
+use falcon_capstone::capstone as cs;
 
 fn main() {
     // Buffer of code.
     let code = vec![0xc3, 0xe9, 0x0b, 0x00, 0x00, 0x00, 0xe8, 0x06, 0x00, 0x00, 0x00];
-    let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::cs_mode::CS_MODE_32).unwrap();
+    let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::CS_MODE_32).unwrap();
 
     // Enable detail mode. This is needed if you want to get instruction details.
     dec.option(cs::cs_opt_type::CS_OPT_DETAIL, cs::cs_opt_value::CS_OPT_ON).unwrap();

--- a/examples/only_str.rs
+++ b/examples/only_str.rs
@@ -1,9 +1,9 @@
 // This example shows how to disassemble some instructions
 // and print them to stdout.
 
-extern crate capstone_rust;
+extern crate falcon_capstone;
 
-use capstone_rust::capstone as cs;
+use falcon_capstone::capstone as cs;
 
 fn main() {
     // Buffer of code.
@@ -13,7 +13,7 @@ fn main() {
     // architecture (x86 in this case) and the hardware mode (32 bit in this case).
     // As many other APIs `new` returns a `Result`, in a less trivial case you should
     // ensure that the API didn't fail.
-    let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::cs_mode::CS_MODE_32).unwrap();
+    let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::CS_MODE_32).unwrap();
 
     // Disassemble the instructions. This function accepts three arguments: the code
     // buffer (a Vec<u8>), the address of the first instruction and the number of

--- a/examples/operands.rs
+++ b/examples/operands.rs
@@ -1,14 +1,14 @@
 // This example shows how to get operands details.
 
-extern crate capstone_rust;
+extern crate falcon_capstone;
 
-use capstone_rust::capstone as cs;
+use falcon_capstone::capstone as cs;
 
 fn main() {
     // Buffer of code.
     let code = vec![0x01, 0xc0, 0x33, 0x19, 0x66, 0x83, 0xeb, 0x0a, 0xe8, 0x0c, 0x00, 0x00,
                     0x00, 0x21, 0x5c, 0xca, 0xfd];
-    let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::cs_mode::CS_MODE_32).unwrap();
+    let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::CS_MODE_32).unwrap();
 
     // Enable detail mode. This is needed if you want to get instruction details.
     dec.option(cs::cs_opt_type::CS_OPT_DETAIL, cs::cs_opt_value::CS_OPT_ON).unwrap();
@@ -29,7 +29,7 @@ fn main() {
 
                 match op.type_ {
                     cs::x86_op_type::X86_OP_REG => {
-                        let reg: &cs::x86_reg = op.reg();
+                        let reg: cs::x86_reg = op.reg();
                         println!("  Register operand: {}", dec.reg_name(reg.as_int()).unwrap());
                         // note: reg can be printed also with the `{:?}` formatter.
                     },
@@ -37,6 +37,7 @@ fn main() {
                         let imm: i64 = op.imm();
                         println!("  Immediate operand: 0x{:x}", imm);
                     },
+                    #[cfg(not(feature = "capstone4"))]
                     cs::x86_op_type::X86_OP_FP => {
                         let fp: f64 = op.fp();
                         println!("  Floating-point operand: {}", fp);
@@ -44,11 +45,11 @@ fn main() {
                     cs::x86_op_type::X86_OP_MEM => {
                         let mem: &cs::x86_op_mem = op.mem();
                         println!("  Memory operand:");
-                        println!("      segment: {}", mem.segment);
-                        println!("      base:    {}", mem.base);
-                        println!("      index:   {}", mem.index);
-                        println!("      scale:   {}", mem.scale);
-                        println!("      disp:    {}", mem.disp);
+                        println!("      segment: {:?}", mem.segment);
+                        println!("      base:    {:?}", mem.base);
+                        println!("      index:   {:?}", mem.index);
+                        println!("      scale:   {:?}", mem.scale);
+                        println!("      disp:    {:?}", mem.disp);
                     },
                     cs::x86_op_type::X86_OP_INVALID => {
                         println!("  Invalid operand");

--- a/src/capstone.rs
+++ b/src/capstone.rs
@@ -16,7 +16,7 @@ use std::mem::transmute;
 /// # Examples
 ///
 /// ```
-/// use capstone_rust::capstone as cs;
+/// use falcon_capstone::capstone as cs;
 ///
 /// let (major, minor, combined) = cs::engine_version();
 /// println!("Capstone version: {}.{}", major, minor);
@@ -39,7 +39,7 @@ pub fn engine_version() -> (i32, i32, u32) {
 /// # Examples
 ///
 /// ```
-/// use capstone_rust::capstone as cs;
+/// use falcon_capstone::capstone as cs;
 ///
 /// let supported = if cs::support_arch(cs::cs_arch::CS_ARCH_ARM) { "is" } else { "isn't" };
 /// println!("The ARM architecture {} supported!", supported);
@@ -101,6 +101,7 @@ fn to_res(code: cs_err) -> Result<(), CsErr> {
 ///
 /// A Rust-friendly struct to access fields of a disassembled instruction. This is a safe wrapper
 /// over cs_insn.
+#[derive(Debug)]
 pub struct Instr {
     /// Instruction ID. Find the instruction id in the '[ARCH]_insn' enum in the header file of
     /// corresponding architecture.
@@ -222,10 +223,10 @@ impl Instr {
 /// # Examples
 ///
 /// ```
-/// use capstone_rust::capstone as cs;
+/// use falcon_capstone::capstone as cs;
 /// let code = vec![0x01, 0xc3]; // add ebx, eax
 ///
-/// let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::cs_mode::CS_MODE_32).unwrap();
+/// let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::CS_MODE_32).unwrap();
 ///
 /// let buf = dec.disasm(code.as_slice(), 0, 0).unwrap();
 /// let add = buf.get(0).unwrap();
@@ -233,7 +234,7 @@ impl Instr {
 ///     assert_eq!(insn, cs::x86_insn::X86_INS_ADD);
 /// }
 /// ```
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum InstrIdArch {
     X86(x86_insn),
     ARM64(arm64_insn),
@@ -253,16 +254,17 @@ pub enum InstrIdArch {
 /// # Examples
 ///
 /// ```
-/// use capstone_rust::capstone as cs;
+/// use falcon_capstone::capstone as cs;
 /// let code = vec![0x01, 0xc3]; // add ebx, eax
 ///
-/// let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::cs_mode::CS_MODE_32).unwrap();
+/// let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::CS_MODE_32).unwrap();
 /// dec.option(cs::cs_opt_type::CS_OPT_DETAIL, cs::cs_opt_value::CS_OPT_ON).unwrap();
 ///
 /// let buf = dec.disasm(code.as_slice(), 0, 0).unwrap();
 /// let detail = buf.get(0).unwrap().detail.unwrap(); // `buf` contains only one 'add'.
 /// assert_eq!(dec.reg_name(detail.regs_write[0]), Some("eflags"));
 /// ```
+#[derive(Debug)]
 pub struct Details {
     /// List of implicit registers read by this insn.
     pub regs_read: Vec<u32>,
@@ -278,6 +280,7 @@ pub struct Details {
 }
 
 /// Architecture-specific part of detail.
+#[derive(Debug)]
 pub enum DetailsArch {
     X86(cs_x86),
     ARM64(cs_arm64),
@@ -292,6 +295,7 @@ pub enum DetailsArch {
 /// Buffer of disassembled instructions.
 ///
 /// Provides a Rust-friendly interface to read the buffer of instructions disassembled by Capstone.
+#[derive(Debug)]
 pub struct InstrBuf {
     ptr: *mut cs_insn,
     count: usize,
@@ -340,6 +344,7 @@ impl InstrBuf {
 /// Disassembled instructions iterator.
 ///
 /// Iterate over the instructions of a buffer of disassembled instructions.
+#[derive(Debug)]
 pub struct InstrIter<'a> {
     buf: &'a InstrBuf,
     current: usize,
@@ -364,6 +369,7 @@ impl<'a> InstrIter<'a> {
 }
 
 /// Capstone handle.
+#[derive(Debug)]
 pub struct Capstone {
     handle: Cell<csh>,
     details_on: Cell<bool>,
@@ -436,20 +442,20 @@ impl Capstone {
     /// # Examples
     ///
     /// ```
-    /// use capstone_rust::capstone as cs;
+    /// use falcon_capstone::capstone as cs;
     /// let code = vec![0x55, 0x48, 0x8b, 0x05, 0xb8, 0x13, 0x00, 0x00];
     ///
-    /// let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::cs_mode::CS_MODE_32).unwrap();
+    /// let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::CS_MODE_32).unwrap();
     /// let buf = dec.disasm(code.as_slice(), 0, 0).unwrap();
     /// for x in buf.iter() {
     ///     println!("{:x}: {} {}", x.address, x.mnemonic, x.op_str);
     /// }
     /// ```
     /// ```
-    /// use capstone_rust::capstone as cs;
+    /// use falcon_capstone::capstone as cs;
     /// let code = vec![0x55, 0x48, 0x8b, 0x05, 0xb8, 0x13, 0x00, 0x00];
     ///
-    /// let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::cs_mode::CS_MODE_32).unwrap();
+    /// let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::CS_MODE_32).unwrap();
     /// let buf = dec.disasm(code.as_slice(), 0, 0).unwrap();
     /// assert_eq!(buf.get(0).unwrap().mnemonic, "push");
     /// assert_eq!(buf.get(1).unwrap().mnemonic, "dec");
@@ -478,9 +484,9 @@ impl Capstone {
     /// # Examples
     ///
     /// ```
-    /// use capstone_rust::capstone as cs;
+    /// use falcon_capstone::capstone as cs;
     ///
-    /// let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::cs_mode::CS_MODE_32).unwrap();
+    /// let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::CS_MODE_32).unwrap();
     /// assert_eq!(dec.reg_name(21).unwrap(), "ebx");
     /// ```
     pub fn reg_name(&self, reg_id: u32) -> Option<&str> {
@@ -506,9 +512,9 @@ impl Capstone {
     /// # Examples
     ///
     /// ```
-    /// use capstone_rust::capstone as cs;
+    /// use falcon_capstone::capstone as cs;
     ///
-    /// let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::cs_mode::CS_MODE_32).unwrap();
+    /// let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::CS_MODE_32).unwrap();
     /// assert_eq!(dec.group_name(2).unwrap(), "call");
     /// ```
     pub fn group_name(&self, group_id: u32) -> Option<&str> {

--- a/src/capstone_sys.rs
+++ b/src/capstone_sys.rs
@@ -26,7 +26,7 @@ pub const CS_MODE_BIG_ENDIAN: cs_mode = cs_mode_CS_MODE_BIG_ENDIAN;
 pub const CS_MODE_MIPS32: cs_mode = cs_mode_CS_MODE_MIPS32;
 pub const CS_MODE_MIPS64: cs_mode = cs_mode_CS_MODE_MIPS64;
 
-// Operand enum getters.
+// Union field getters.
 impl cs_x86_op {
     pub fn reg(&self) -> x86_reg {
         return unsafe { self.__bindgen_anon_1.reg };
@@ -151,180 +151,43 @@ impl cs_xcore_op {
     }
 }
 
+macro_rules! impl_from_into_int {
+    ($name:ident) => {
+        impl From<u32> for $name {
+            fn from(i: u32) -> Self {
+                unsafe { transmute(i) }
+            }
+        }
+        impl Into<u32> for $name {
+            fn into(self) -> u32 {
+                unsafe { transmute(self) }
+            }
+        }
+        impl $name {
+            pub fn as_int(&self) -> u32 {
+                (*self).into()
+            }
+        }
+    };
+}
+
 // Register: enum <-> integer
-impl From<u32> for x86_reg {
-    fn from(i: u32) -> Self {
-        return unsafe { transmute::<u32, Self>(i) }
-    }
-}
-impl x86_reg {
-    pub fn as_int(&self) -> u32 {
-        return unsafe { transmute::<Self, u32>(*self) }
-    }
-}
+impl_from_into_int!(arm_reg);
+impl_from_into_int!(arm64_reg);
+impl_from_into_int!(mips_reg);
+impl_from_into_int!(x86_reg);
+impl_from_into_int!(ppc_reg);
+impl_from_into_int!(sparc_reg);
+impl_from_into_int!(sysz_reg);
+impl_from_into_int!(xcore_reg);
 
-impl From<u32> for arm64_reg {
-    fn from(i: u32) -> Self {
-        return unsafe { transmute::<u32, Self>(i) }
-    }
-}
-impl arm64_reg {
-    pub fn as_int(&self) -> u32 {
-        return unsafe { transmute::<Self, u32>(*self) }
-    }
-}
-
-impl From<u32> for arm_reg {
-    fn from(i: u32) -> Self {
-        return unsafe { transmute::<u32, Self>(i) }
-    }
-}
-impl arm_reg {
-    pub fn as_int(&self) -> u32 {
-        return unsafe { transmute::<Self, u32>(*self) }
-    }
-}
-
-impl From<u32> for mips_reg {
-    fn from(i: u32) -> Self {
-        return unsafe { transmute::<u32, Self>(i) }
-    }
-}
-impl mips_reg {
-    pub fn as_int(&self) -> u32 {
-        return unsafe { transmute::<Self, u32>(*self) }
-    }
-}
-
-impl From<u32> for ppc_reg {
-    fn from(i: u32) -> Self {
-        return unsafe { transmute::<u32, Self>(i) }
-    }
-}
-impl ppc_reg {
-    pub fn as_int(&self) -> u32 {
-        return unsafe { transmute::<Self, u32>(*self) }
-    }
-}
-
-impl From<u32> for sparc_reg {
-    fn from(i: u32) -> Self {
-        return unsafe { transmute::<u32, Self>(i) }
-    }
-}
-impl sparc_reg {
-    pub fn as_int(&self) -> u32 {
-        return unsafe { transmute::<Self, u32>(*self) }
-    }
-}
-
-impl From<u32> for sysz_reg {
-    fn from(i: u32) -> Self {
-        return unsafe { transmute::<u32, Self>(i) }
-    }
-}
-impl sysz_reg {
-    pub fn as_int(&self) -> u32 {
-        return unsafe { transmute::<Self, u32>(*self) }
-    }
-}
-
-impl From<u32> for xcore_reg {
-    fn from(i: u32) -> Self {
-        return unsafe { transmute::<u32, Self>(i) }
-    }
-}
-impl xcore_reg {
-    pub fn as_int(&self) -> u32 {
-        return unsafe { transmute::<Self, u32>(*self) }
-    }
-}
 
 // Groups: enum <-> integer.
-impl From<u32> for x86_insn_group {
-    fn from(i: u32) -> Self {
-        return unsafe { transmute::<u32, Self>(i) }
-    }
-}
-impl x86_insn_group {
-    pub fn as_int(&self) -> u32 {
-        return unsafe { transmute::<Self, u32>(*self) }
-    }
-}
-
-impl From<u32> for arm64_insn_group {
-    fn from(i: u32) -> Self {
-        return unsafe { transmute::<u32, Self>(i) }
-    }
-}
-impl arm64_insn_group {
-    pub fn as_int(&self) -> u32 {
-        return unsafe { transmute::<Self, u32>(*self) }
-    }
-}
-
-impl From<u32> for arm_insn_group {
-    fn from(i: u32) -> Self {
-        return unsafe { transmute::<u32, Self>(i) }
-    }
-}
-impl arm_insn_group {
-    pub fn as_int(&self) -> u32 {
-        return unsafe { transmute::<Self, u32>(*self) }
-    }
-}
-
-impl From<u32> for mips_insn_group {
-    fn from(i: u32) -> Self {
-        return unsafe { transmute::<u32, Self>(i) }
-    }
-}
-impl mips_insn_group {
-    pub fn as_int(&self) -> u32 {
-        return unsafe { transmute::<Self, u32>(*self) }
-    }
-}
-
-impl From<u32> for ppc_insn_group {
-    fn from(i: u32) -> Self {
-        return unsafe { transmute::<u32, Self>(i) }
-    }
-}
-impl ppc_insn_group {
-    pub fn as_int(&self) -> u32 {
-        return unsafe { transmute::<Self, u32>(*self) }
-    }
-}
-
-impl From<u32> for sparc_insn_group {
-    fn from(i: u32) -> Self {
-        return unsafe { transmute::<u32, Self>(i) }
-    }
-}
-impl sparc_insn_group {
-    pub fn as_int(&self) -> u32 {
-        return unsafe { transmute::<Self, u32>(*self) }
-    }
-}
-
-impl From<u32> for sysz_insn_group {
-    fn from(i: u32) -> Self {
-        return unsafe { transmute::<u32, Self>(i) }
-    }
-}
-impl sysz_insn_group {
-    pub fn as_int(&self) -> u32 {
-        return unsafe { transmute::<Self, u32>(*self) }
-    }
-}
-
-impl From<u32> for xcore_insn_group {
-    fn from(i: u32) -> Self {
-        return unsafe { transmute::<u32, Self>(i) }
-    }
-}
-impl xcore_insn_group {
-    pub fn as_int(&self) -> u32 {
-        return unsafe { transmute::<Self, u32>(*self) }
-    }
-}
+impl_from_into_int!(arm_insn_group);
+impl_from_into_int!(arm64_insn_group);
+impl_from_into_int!(mips_insn_group);
+impl_from_into_int!(x86_insn_group);
+impl_from_into_int!(ppc_insn_group);
+impl_from_into_int!(sparc_insn_group);
+impl_from_into_int!(sysz_insn_group);
+impl_from_into_int!(xcore_insn_group);

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,11 +1,11 @@
-extern crate capstone_rust;
+extern crate falcon_capstone;
 
-use capstone_rust::capstone as cs;
+use falcon_capstone::capstone as cs;
 
 #[test]
 fn single_instr() {
     let code = vec![0xe9, 0x0c, 0x00, 0x00, 0x00];
-    let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::cs_mode::CS_MODE_32).unwrap();
+    let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::CS_MODE_32).unwrap();
 
     let buf = dec.disasm(code.as_slice(), 0, 0).unwrap();
 
@@ -20,7 +20,7 @@ fn single_instr() {
 #[test]
 fn multiple_instr() {
     let code = vec![0x83, 0xc3, 0x02, 0x66, 0xb8, 0x2c, 0x00, 0x55, 0x8d, 0x73, 0x10];
-    let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::cs_mode::CS_MODE_32).unwrap();
+    let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::CS_MODE_32).unwrap();
 
     dec.option(cs::cs_opt_type::CS_OPT_DETAIL, cs::cs_opt_value::CS_OPT_ON).unwrap();
 
@@ -49,7 +49,13 @@ fn multiple_instr() {
 
     let instr4 = buf.get(3).unwrap();
     assert_eq!(instr4.mnemonic, "lea");
-    assert_eq!(instr4.op_str, "esi, dword ptr [ebx + 0x10]");
+    assert_eq!(instr4.op_str,
+        if cfg!(feature = "capstone4") {
+            // Capstone 4 changed the pretty printing format slightly
+            "esi, [ebx + 0x10]"
+        } else {
+            "esi, dword ptr [ebx + 0x10]"
+        });
     assert_eq!(instr4.address, 8);
     assert_eq!(instr4.id, cs::InstrIdArch::X86(cs::x86_insn::X86_INS_LEA));
     assert_eq!(instr4.size, 3);

--- a/tests/details.rs
+++ b/tests/details.rs
@@ -1,11 +1,11 @@
-extern crate capstone_rust;
+extern crate falcon_capstone;
 
-use capstone_rust::capstone as cs;
+use falcon_capstone::capstone as cs;
 
 #[test]
 fn implicit() {
     let code = vec![0x01, 0xdd, 0xe8, 0x06, 0x00, 0x00, 0x00];
-    let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::cs_mode::CS_MODE_32).unwrap();
+    let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::CS_MODE_32).unwrap();
     dec.option(cs::cs_opt_type::CS_OPT_DETAIL, cs::cs_opt_value::CS_OPT_ON).unwrap();
 
     let buf = dec.disasm(code.as_slice(), 0, 0).unwrap();
@@ -20,7 +20,7 @@ fn implicit() {
 #[test]
 fn operands() {
     let code = vec![0x2b, 0x72, 0x05];
-    let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::cs_mode::CS_MODE_32).unwrap();
+    let dec = cs::Capstone::new(cs::cs_arch::CS_ARCH_X86, cs::CS_MODE_32).unwrap();
     dec.option(cs::cs_opt_type::CS_OPT_DETAIL, cs::cs_opt_value::CS_OPT_ON).unwrap();
 
     let buf = dec.disasm(code.as_slice(), 0, 0).unwrap();
@@ -32,10 +32,10 @@ fn operands() {
 
         let op2 = arch.operands[1];
         let mem = op2.mem();
-        assert_eq!(op2.type_, cs::x86_op_type::X86_OP_MEM);
-        assert_eq!(mem.segment, 0);
-        assert_eq!(mem.base, 24);
-        assert_eq!(mem.index, 0);
+        assert_eq!(op2.type_, cs::x86_op_type::X86_OP_MEM.into());
+        assert_eq!(mem.segment, cs::x86_reg::X86_REG_INVALID.into());
+        assert_eq!(mem.base, cs::x86_reg::X86_REG_EDX.into());
+        assert_eq!(mem.index, cs::x86_reg::X86_REG_INVALID.into());
         assert_eq!(mem.scale, 1);
         assert_eq!(mem.disp, 5);
     }


### PR DESCRIPTION
Bumps dependency version for bindgen, for better Debug implementations.
Fix tests and examples so they compile under this version of the crate.
Consideration was also given to Capstone 4 support, although it is not
implemented in this commit.

Fixes falconre#4