### PR TITLE
Support capstone static link via optional feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ version = "0.4.1"
 dependencies = [
  "bindgen",
  "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -202,6 +203,12 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ capstone4 = []
 
 [build-dependencies]
 bindgen = "0.51.0"
+pkg-config = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,15 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
+    #[cfg(not(feature = "static"))]
     println!("cargo:rustc-link-lib=capstone");
+
+    #[cfg(feature = "static")]
+    println!("cargo:rustc-link-lib=static=capstone");
+
+    // https://github.com/aquynh/capstone/blob/71f5c64c43b9868ab08c3a9bad82ba3563e9436d/COMPILE.TXT#L100
+    #[cfg(all(feature = "static", target_os = "linux"))]
+    println!("cargo:rustc-link-search=native=/usr/lib");
 
     let bindings = bindgen::Builder::default()
         .header("src/wrapper.h")

--- a/build.rs
+++ b/build.rs
@@ -10,9 +10,11 @@ fn main() {
     #[cfg(feature = "static")]
     println!("cargo:rustc-link-lib=static=capstone");
 
-    // https://github.com/aquynh/capstone/blob/71f5c64c43b9868ab08c3a9bad82ba3563e9436d/COMPILE.TXT#L100
-    #[cfg(all(feature = "static", target_os = "linux"))]
-    println!("cargo:rustc-link-search=native=/usr/lib");
+    #[cfg(all(feature = "capstone4", feature = "static", target_os = "linux"))]
+    pkg_config::Config::new().atleast_version("4.0.0").statik(true).probe("capstone").unwrap();
+
+    #[cfg(all(not(feature = "capstone4"), feature = "static", target_os = "linux"))]
+    pkg_config::Config::new().statik(true).probe("capstone").unwrap();
 
     let bindings = bindgen::Builder::default()
         .header("src/wrapper.h")


### PR DESCRIPTION
**What:**

Implemented the [already existing!] feature flag `static` to statically link in `capstone` at compile-time, instead of relying on the presence of a shared object.

**Why:**

I'm experimenting with a [plugin](https://github.com/panda-re/panda-rs-plugins/tree/master/panda-il-trace) that uses `falcon`.  I have to support deploying an an environment that uses the latest `libcapstone-dev` available on Ubuntu 20.04, which is currently v4.0.1, but would still like to have `falcon` use v4.0.2 (about 5 months newer).

I imagine others may want this optional feature for similar portability reasons. 